### PR TITLE
Implements The Default Ear System

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -382,7 +382,14 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			pref.s_tone = 0
 			pref.age = max(min(pref.age, mob_species.max_age), mob_species.min_age)
 
-			pref.custom_species = null //MITHRAstation Edit - This is cleared on species changes
+		//MITHRA STATION EDITS - START
+			var/datum/species/HALP = all_species[pref.species]
+			pref.custom_species = null //This is cleared on species changes
+			if(!pref.ear_style)	//if no custom ear selected...
+				pref.ear_style = HALP.default_ears	//use species' default ear
+
+		//MITHRA STATION EDITS - END
+
 			reset_limbs() // Safety for species with incompatible manufacturers; easier than trying to do it case by case.
 			pref.body_markings.Cut() // Basically same as above.
 

--- a/modular_mithra/code/modules/species/station/custom.dm
+++ b/modular_mithra/code/modules/species/station/custom.dm
@@ -6,6 +6,7 @@
 	var/base_species = null // Unused outside of certain stuff
 	var/selects_bodytype = FALSE // Allows the species to choose from body types intead of being forced to be just one.
 	var/modular_tail
+	var/default_ears
 
 /mob/living/carbon/human/proc/get_display_species()
 

--- a/modular_mithra/code/modules/species/station/vulpkanin.dm
+++ b/modular_mithra/code/modules/species/station/vulpkanin.dm
@@ -8,6 +8,7 @@
 	tail = "vulptail"
 	limb_blend = ICON_MULTIPLY
 	tail_blend = ICON_MULTIPLY
+	default_ears = "vulpkanin, dual-color"
 	hidden_from_codex = FALSE
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/claws)


### PR DESCRIPTION
This PR makes it so that switching to any species with a default ear defined will automatically give you the default ear, assuming you do not already have a custom earstyle selected, or an earstyle from any previous default ear additions.