### PR TITLE
Vulpkanin Default Ear Hotfix

### DIFF
--- a/modular_mithra/code/modules/species/station/vulpkanin.dm
+++ b/modular_mithra/code/modules/species/station/vulpkanin.dm
@@ -9,7 +9,7 @@
 	tail = "vulptail"
 	limb_blend = ICON_MULTIPLY
 	tail_blend = ICON_MULTIPLY
-	default_ears = "vulpkanin, dual-color"
+	default_ears = /datum/sprite_accessory/ears/vulp
 	hidden_from_codex = FALSE
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/claws)


### PR DESCRIPTION
This PR fixes vulpkanin's default ear procs. Where I used the name of the ear, it was supposed to be the typepath of the ear.