### PR TITLE
Adds "shift + MMB" shortcut for pointing, and fixes random bugs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,13 @@
 # can intervene and prevent regressions to our code.
 
 # The following are related to custom species code. As Toriate did the majority of the work on them, they will handle them.
-code/game/dna/dna2.dm @Michiyamenotehifunana
-code/game/dna/dna2_helpers.dm @Michiyamenotehifunana
-code/modules/mob/living/carbon/human/update_icons.dm @Michiyamenotehifunana
-code/modules/mob/living/carbon/human/examine.dm @Michiyamenotehifunana
-code/modules/organs/external/_external_icons.dm @Michiyamenotehifunana
-code/modules/organs/external/head.dm @Michiyamenotehifunana
-code/modules/organs/organ.dm @Michiyamenotehifunana
-code/modules/client/preference_setup/02_body.dm @Michiyamenotehifunana
-code/game/gamemodes/changeling/changeling_powers.dm	@Michiyamenotehifunana
+/code/game/dna/dna2.dm @Michiyamenotehifunana
+/code/game/dna/dna2_helpers.dm @Michiyamenotehifunana
+/code/modules/mob/living/carbon/human/update_icons.dm @Michiyamenotehifunana
+/code/modules/mob/living/carbon/human/examine.dm @Michiyamenotehifunana
+/code/modules/organs/external/_external_icons.dm @Michiyamenotehifunana
+/code/modules/organs/external/head.dm @Michiyamenotehifunana
+/code/modules/organs/organ.dm @Michiyamenotehifunana
+/code/modules/client/preference_setup/02_body.dm @Michiyamenotehifunana
+/code/game/gamemodes/changeling/changeling_powers.dm	@Michiyamenotehifunana
+/code/_onclick/click.dm	@Michiyamenotehifunana

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2920,6 +2920,7 @@
 #include "maps\~unit_tests\unit_testing.dm"
 #include "modular_mithra\code\__defines\misc.dm"
 #include "modular_mithra\code\__defines\mobs.dm"
+#include "modular_mithra\code\_onclick\click.dm"
 #include "modular_mithra\code\datums\mutable_appearance.dm"
 #include "modular_mithra\code\game\machinery\suit_storage_unit.dm"
 #include "modular_mithra\code\modules\client\preference_setup\loadout\geartweaks.dm"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -45,6 +45,11 @@
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
+	//MITHRAstation edit START - Adds shift+middle click shortcut. This edit is not modularised due to the performance impact of modular callbacks on such an essential proc.
+	if(modifiers["shift"] && modifiers["middle"])
+		ShiftMiddleClickOn(A)
+		return 1
+	//MITHRAstation edit END
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return 1

--- a/modular_mithra/code/_onclick/click.dm
+++ b/modular_mithra/code/_onclick/click.dm
@@ -1,0 +1,5 @@
+//This file works together with our non-modular edit in click.dm in order to implement the shift-middle-click to point shortcut.
+
+/mob/proc/ShiftMiddleClickOn(atom/A)
+	src.pointed(A)
+	return

--- a/modular_mithra/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/modular_mithra/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -135,4 +135,12 @@
 /obj/item/clothing/gloves/rig/command
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_AKULA,SPECIES_VULP,SPECIES_VASS,SPECIES_TAJ)
 
+//////////////////NULL//////////////////////////
+
+/obj/item/clothing/head/helmet/space/rig/zero
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_AKULA,SPECIES_VULP,SPECIES_VASS,SPECIES_TAJ)
+
+/obj/item/clothing/suit/space/rig/zero
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_AKULA,SPECIES_VULP,SPECIES_VASS,SPECIES_TAJ)
+
 //The antag hardsuits are not species locked


### PR DESCRIPTION
:cl: Toriate
rscadd: New shift+midleclick shortcut added for pointing
tweak: Null Hardsuit now useable by all our species
/:cl:

This PR additionally also updates our codeowners file.

The shift+middleclick definition is not made modular due to the potential performance impact of calling `. = ..()` in such an essential proc, however the proc that actually does the pointing is modular.