### PR TITLE
Ports mech strafing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,4 @@ code/modules/organs/external/head.dm @Michiyamenotehifunana
 code/modules/organs/organ.dm @Michiyamenotehifunana
 code/modules/client/preference_setup/02_body.dm @Michiyamenotehifunana
 code/game/gamemodes/changeling/changeling_powers.dm	@Michiyamenotehifunana
+/code/game/mecha/mecha.dm	@Michiyamenotehifunana

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2922,6 +2922,7 @@
 #include "modular_mithra\code\__defines\mobs.dm"
 #include "modular_mithra\code\datums\mutable_appearance.dm"
 #include "modular_mithra\code\game\machinery\suit_storage_unit.dm"
+#include "modular_mithra\code\game\mecha\mecha_actions.dm"
 #include "modular_mithra\code\modules\client\preference_setup\loadout\geartweaks.dm"
 #include "modular_mithra\code\modules\client\preference_setup\loadout\lists\clothing.dm"
 #include "modular_mithra\code\modules\clothing\polychrome.dm"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -81,6 +81,8 @@
 	var/max_equip = 3
 	var/datum/events/events
 
+	var/strafe = FALSE	//MITHRAstation edit - if we're strafing
+
 /obj/mecha/drain_power(var/drain_check)
 
 	if(drain_check)
@@ -379,7 +381,7 @@
 	var/move_result = 0
 	if(hasInternalDamage(MECHA_INT_CONTROL_LOST))
 		move_result = mechsteprand()
-	else if(src.dir!=direction)
+	else if(src.dir!=direction && !strafe)	//MITHRAstation edit - the main magic in strafecode
 		move_result = mechturn(direction)
 	else
 		move_result	= mechstep(direction)
@@ -403,7 +405,10 @@
 	return 1
 
 /obj/mecha/proc/mechstep(direction)
+	var/current_dir = dir	//MITHRAstation edit - strafecode
 	var/result = step(src,direction)
+	if(strafe)				//MITHRAstation edit - strafecode
+		set_dir(current_dir)	//MITHRAstation edit - strafecode
 	if(result)
 		playsound(src,'sound/mecha/mechstep.ogg',40,1)
 	return result

--- a/modular_mithra/README.md
+++ b/modular_mithra/README.md
@@ -23,3 +23,4 @@ If for whatever reason you are unable to maintain modularity and have to modify 
   - `code/modules/organs/organ.dm`
   - `code/modules/client\preference_setup\02_body.dm`
   - `code/game/gamemodes/changeling/changeling_powers.dm`
+  - `code/game/mecha/mecha.dm`

--- a/modular_mithra/code/game/mecha/mecha_actions.dm
+++ b/modular_mithra/code/game/mecha/mecha_actions.dm
@@ -1,0 +1,11 @@
+//This file works alongside our non-modular changes in mecha.dm to allow the toggling of strafing.
+
+/obj/mecha/AltClick(mob/living/user)
+	if(user == occupant)
+		toggle_strafe()
+
+/obj/mecha/proc/toggle_strafe()
+	strafe = !strafe
+
+	occupant_message("Toggled strafing mode [strafe?"on":"off"].")
+	log_message("Toggled strafing mode [strafe?"on":"off"].")


### PR DESCRIPTION
Alt-click to toggle strafing. Surprisingly, the strafing code works perfectly fine with skillcode, which can make you stumble randomly into objects when you are untrained.

Mecha.dm had to be unmodularly edited due to the way the code works.