### PR TITLE
Advances time by 2 years

### DIFF
--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -5,7 +5,7 @@ GLOBAL_VAR_INIT(max_explosion_range, 14)
 var/href_logfile        = null
 var/game_version        = "Baystation12"
 var/changelog_hash      = ""
-var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 544)
+var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 546) //MITHRAstation edit - for lore purposes
 var/join_motd = null
 
 var/secret_force_mode = "secret"   // if this is anything but "secret", the secret rotation will forceably choose this mode.


### PR DESCRIPTION
So that in 2019, the in-game year would be 2565 rather than 2563.